### PR TITLE
Allowing boolean state to work when falsy

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [Svelte] is the smallest JS framework, but even so, it contains many built-in features. One of them is a `svelte/store`. But why we need to use a third-party store? `@storeon/svelte` has several advantages compared with the built-in one.
 
-- **Size**. 177 bytes (+ Storeon itself) instead of 485 bytes (minified and gzipped).
+- **Size**. 179 bytes (+ Storeon itself) instead of 485 bytes (minified and gzipped).
 - **Ecosystem**. Many additional [tools] can be combined with a store.
 - **Speed**. Bind components to the changes in the exact store that you need.
 

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ function useStoreon (...keys) {
 
   store.on('@changed', (_, changed) => {
     keys.forEach(key => {
-      if (changed[key] && subscribers[key]) {
+      if (subscribers[key]) {
         subscribers[key](changed[key])
       }
     })

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ function useStoreon (...keys) {
 
   store.on('@changed', (_, changed) => {
     keys.forEach(key => {
-      if (subscribers[key]) {
+      if (changed.hasOwnProperty(key) && subscribers[key]) {
         subscribers[key](changed[key])
       }
     })

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ function useStoreon (...keys) {
 
   store.on('@changed', (_, changed) => {
     keys.forEach(key => {
-      if (changed[key] && subscribers[key]) {
+      if (key in changed && subscribers[key]) {
         subscribers[key](changed[key])
       }
     })

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
       "import": {
         "index.js": "{ provideStoreon, useStoreon }"
       },
-      "limit": "177 B",
+      "limit": "179 B",
       "ignore": [
         "svelte"
       ]

--- a/sandbox.config.json
+++ b/sandbox.config.json
@@ -1,3 +1,0 @@
-{
-  "template": "node"
-}

--- a/sandbox.config.json
+++ b/sandbox.config.json
@@ -1,0 +1,3 @@
+{
+  "template": "node"
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -8,10 +8,13 @@ jest.mock('svelte')
 function setupStore () {
   function counter (store) {
     store.on('@init', () => {
-      return { count: 0, foo: 'baz' }
+      return { count: 0, foo: 'baz', loading: false }
     })
     store.on('inc', state => {
       return { count: state.count + 1 }
+    })
+    store.on('toggle', state => {
+      return { loading: !state.loading }
     })
   }
 
@@ -93,7 +96,7 @@ it('should not emit changes on other dispatches', () => {
   expect(countSpyCb).toHaveBeenCalledTimes(1)
 })
 
-it('shoud to be unsubscribed', () => {
+it('should to be unsubscribed', () => {
   let currentValue
   let { count, dispatch } = useStoreon('count')
 
@@ -110,4 +113,27 @@ it('shoud to be unsubscribed', () => {
   dispatch('inc')
 
   expect(currentValue).toBe(1)
+})
+
+it('should work with boolean values', () => {
+  let currentValue
+  let { loading, dispatch } = useStoreon('loading')
+
+  let unsubscribe = loading.subscribe(value => { currentValue = value })
+
+  expect(currentValue).toBe(false)
+
+  dispatch('toggle')
+
+  expect(currentValue).toBe(true)
+
+  dispatch('toggle')
+
+  expect(currentValue).toBe(false)
+
+  unsubscribe()
+
+  dispatch('toggle')
+
+  expect(currentValue).toBe(false)
 })


### PR DESCRIPTION
The problem:

If we have a store like: 

```js
cons store = store => {
  store.on('@init', () => ({
    isLoading: false
  }))

  store.on('toggle', ({ isLoading }) => ({
    isLoading: !isLoading
  }))
}
```

The `isLoading` state will never be reactive in svelte when it's value changes to `false`.